### PR TITLE
added support for initializers to be typed

### DIFF
--- a/src/SyntaxKindDelegator.ts
+++ b/src/SyntaxKindDelegator.ts
@@ -47,7 +47,9 @@ export const SyntaxKindDelegator: SyntaxKindValidatorMap = {
 	[SK.SetAccessor]: Node.isSetAccessorDeclaration,
 	[SK.ConditionalType]: Node.isConditionalTypeNode,
 	[SK.VariableStatement]: Node.isVariableStatement,
-	[SK.VariableDeclaration]: Node.isVariableDeclaration
+	[SK.VariableDeclaration]: Node.isVariableDeclaration,
+	[SK.FunctionExpression]: Node.isFunctionExpression,
+	[SK.ArrowFunction]: Node.isArrowFunction
 };
 
 export const bySyntax = <T>(node: Nodely, skMap: Partial<SyntaxKindMap<T>>, defaultFN: (node: Nodely)=>T): T => {

--- a/src/SyntaxKindDelegator.types.ts
+++ b/src/SyntaxKindDelegator.types.ts
@@ -1,4 +1,4 @@
-import { ArrayLiteralExpression, ArrayTypeNode, ClassDeclaration, ClassStaticBlockDeclaration, ConditionalTypeNode, Constructor, ConstructorDeclaration, ConstructorTypeNode, Expression, ExpressionWithTypeArguments, FunctionTypeNode, GetAccessorDeclaration, Identifier, InterfaceDeclaration, IntersectionTypeNode, LiteralTypeNode, MethodDeclaration, MethodSignature, NamedTupleMember, Node, NumericLiteral, ParameterDeclaration, ParenthesizedTypeNode, PropertyDeclaration, PropertySignature, SetAccessorDeclaration, SyntaxKind as SK, SourceFile, StringLiteral, SyntaxList, TupleTypeNode, TypeAliasDeclaration, TypeLiteralNode, TypeNode, TypeParameterDeclaration, TypeReferenceNode, UnionTypeNode, VariableDeclaration, VariableStatement } from "ts-morph";
+import { ArrayLiteralExpression, ArrayTypeNode, ArrowFunction, ClassDeclaration, ClassStaticBlockDeclaration, ConditionalTypeNode, Constructor, ConstructorDeclaration, ConstructorTypeNode, Expression, ExpressionWithTypeArguments, FunctionExpression, FunctionTypeNode, GetAccessorDeclaration, Identifier, InterfaceDeclaration, IntersectionTypeNode, LiteralTypeNode, MethodDeclaration, MethodSignature, NamedTupleMember, Node, NumericLiteral, ParameterDeclaration, ParenthesizedTypeNode, PropertyDeclaration, PropertySignature, SetAccessorDeclaration, SyntaxKind as SK, SourceFile, StringLiteral, SyntaxList, TupleTypeNode, TypeAliasDeclaration, TypeLiteralNode, TypeNode, TypeParameterDeclaration, TypeReferenceNode, UnionTypeNode, VariableDeclaration, VariableStatement } from "ts-morph";
 import { Nodely } from "./types";
 
 /**
@@ -57,7 +57,9 @@ export interface SyntaxKindTypeMap<T=never> {
 	[SK.SetAccessor]: SetAccessorDeclaration,
 	[SK.ConditionalType]: ConditionalTypeNode,
 	[SK.VariableStatement]: VariableStatement,
-	[SK.VariableDeclaration]: VariableDeclaration
+	[SK.VariableDeclaration]: VariableDeclaration,
+	[SK.FunctionExpression]: FunctionExpression,
+	[SK.ArrowFunction]: ArrowFunction
 }
 
 export type TypeByKind<T extends keyof SyntaxKindTypeMap> = SyntaxKindTypeMap[T]

--- a/src/node-signature.ts
+++ b/src/node-signature.ts
@@ -96,6 +96,9 @@ const typingMap: SKindMap<string> = {
 	[SK.MethodDeclaration]: node=>{
 		return `(${node.getParameters().map(p=>sig(p)).join(', ')}) =&gt; ${sig(node.getReturnTypeNode()) || $literal('void')}`;
 	},
+	[SK.ArrowFunction]: node=>{
+		return `(${node.getParameters().map(p=>sig(p)).join(', ')}) =&gt; ${sig(node.getReturnTypeNode()) || $literal('void')}`;
+	},
 	[SK.ParenthesizedType]: node=>`(${fromTypeNode(node)})`,
 	[SK.ClassDeclaration]: node=>{
 		const extensions = sig(node.getExtends());
@@ -117,7 +120,16 @@ const typingMap: SKindMap<string> = {
 	[SK.ConditionalType]: node => {
 		return `${sig(node.getCheckType())} extends ${sig(node.getExtendsType())} ? ${sig(node.getTrueType())}<br/>: ${sig(node.getFalseType())}`;
 	},
-	[SK.VariableDeclaration]: fromTypeNode
+	[SK.VariableDeclaration]: node => {
+		const tn = fromTypeNode(node);
+		if(tn) return tn;
+		const init = node.getInitializer();
+		return sig(init);
+	},
+
+	[SK.FunctionExpression]: node => {
+		return `(${node.getParameters().map(p=>sig(p)).join(', ')}) =&gt; ${sig(node.getReturnTypeNode()) || $literal('void')}`;
+	}
 }
 const defSig = (n: Nodely)=>{
 	if(!n) return '';
@@ -139,6 +151,7 @@ export const fromType = (t: Type) => isPrimitiveType(t) ? $type(t.getText())
 : '';
 export const getSignatureFromType = (node: Nodely) => {
 	if(!node) return;
-	const t = node.getType();
+	//const t = node.getType();
+	//console.log(t.getText(), node.getKindName())
 	return '';
 }

--- a/src/node-tools.ts
+++ b/src/node-tools.ts
@@ -103,7 +103,7 @@ const ModMap: SKindMap<Modificator> = {
 }
 
 export const getTypeNode = (node?: Node) => Node.isTyped(node) ? node.getTypeNode()
-	: (Node.isInitializerExpressionGetable(node) || Node.isInitializerExpressionable(node)) ? node.getInitializer()
+	//: (Node.isInitializerExpressionGetable(node) || Node.isInitializerExpressionable(node)) ? node.getInitializer()
 	: undefined;
 /**
  * In some cases the named node is the parent node of the evaluated node this just climbs the node tree until it finds a name


### PR DESCRIPTION
contributes to #13 


If a type node is not present I will dive into the initializer express if one exists to try to infer a node.