### PR TITLE
Type fallback when typenode is not available.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 src/
 node_modules/
 tsconfig.json
+jest.config.js
+.gitignore
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@irwinproject/storybook-addon-tsdoc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@irwinproject/storybook-addon-tsdoc",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "console-log-colors": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "minimatch": "^10.0.1",
     "ts-morph": "^24.0.0"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/node-signature.ts
+++ b/src/node-signature.ts
@@ -251,8 +251,15 @@ export const fromType = (t: Type | undefined):string => {
 	const [symbol] = t?.getSymbol()?.getDeclarations() ?? [];
 	const [aliasSymbol] = t?.getAliasSymbol()?.getDeclarations() ?? [];
 	const node = symbol ?? aliasSymbol
-	if(t?.isAnonymous() || !node) return sig(node);
-	console.log(node);
+	if(t?.isAnonymous()) return sig(node);
+	if(!node) return '';
+	console.log(node.getKindName(), Node.isExpression(node))
+	if(Node.isExpression(node)) {
+		const p = node.getParent();
+		if(!p) return '';
+		const href = getDocPath(p);
+		return href ? $href(getName(p), href):$type(getName(p));
+	}
 	const href = getDocPath(node)
 	
 	return href ? $href(getName(node), href):$type(getName(node));

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -248,7 +248,7 @@ const RENDER_MAP: SKindMap<string> = {
 		$h(4, node, $kd`property`, getSignature(node)),
 		getComments(node),
 		getExample(node),
-		build()
+		build(node.getInitializer())
 	),
 	[SK.NewExpression]: ()=>``
 };
@@ -264,9 +264,15 @@ export const buildFromType = (type: Type) => {
 	const node = declarationOfType(type);
 	if(!node) return;
 	if(type.isAnonymous()) return build(node);
-	const href = getDocPath(node)
+	if(Node.isExpression(node)){
+		const p = node.getParent();
+		if(!p) return '';
+		const href = getDocPath(p);
+		return `<h4 className="ts-doc-header">${href ? $href(getName(p), href):$type(getName(p))}</h4>`;
+	}
+	const href = getDocPath(node);
 	
-	return href ? $href(getName(node), href):$type(getName(node));
+	return `<h4 className="ts-doc-header">${href ? $href(getName(node), href):$type(getName(node))}</h4>`;
 }
 /**
  * Builds based on a list of nodes. 


### PR DESCRIPTION
In an instance when a type node is not present now the type is evaluated.

When a fallback to a type occurs the declaration node is found and parsed for a type. 

The first corner case that becomes apparent is the declaration node will be parsed only if the declaration is anonymous. (This still raising the concern what happens if an anonymous array literal or Object literal are passed).

The second corner case becomes problematic when referencing expressions. Because everything can be declared anonymously such occurrences are treated as expressions of a variable. when referencing such expressions the parent of the expression needs to be referenced instead. (While I know this has been addressed in this use case. There may be additional uses cases where expressions are referenced instead of statements or declarations.)