### PR TITLE
Feature gen sig

### DIFF
--- a/src/SyntaxKindDelegator.ts
+++ b/src/SyntaxKindDelegator.ts
@@ -1,5 +1,6 @@
-import { SyntaxKindMap, SyntaxKindValidatorMap } from "./SyntaxKindDelegator.types";
-import { SyntaxKindDelegator } from "./SyntaxKindMap";
+import { Node } from "ts-morph";
+import SK, { SyntaxKindDelegateAction, SyntaxKindMap, SyntaxKindValidatorMap } from "./SyntaxKindDelegator.types";
+import { SyntaxKindDelegator, SyntaxKindTypeMap } from "./SyntaxKindMap";
 import { Nodely } from "./types";
 
 /**
@@ -25,3 +26,5 @@ export const bySyntax = <T>(
 	//@ts-ignore
 	return entry(node, defaultFN);
 }
+
+export const combineSyntax = <K extends keyof SyntaxKindTypeMap, T>(keys: K[], action: SyntaxKindDelegateAction<SyntaxKindTypeMap[K], T>):Partial<SyntaxKindMap<T>> => keys.reduce((o,v)=>({...o, [v]:action}), {});

--- a/src/SyntaxKindMap.ts
+++ b/src/SyntaxKindMap.ts
@@ -1,7 +1,7 @@
 import { ArrayBindingPattern, ArrayLiteralExpression, ArrayTypeNode, ArrowFunction, BigIntLiteral, BinaryExpression, BindingElement, CallExpression, ClassDeclaration, ClassExpression, ClassStaticBlockDeclaration, ConditionalTypeNode, ConstructorDeclaration, EnumDeclaration, EnumMember, ExportDeclaration, Expression, ExpressionStatement, ExpressionWithTypeArguments, FalseLiteral, FunctionDeclaration, FunctionExpression, FunctionTypeNode, GetAccessorDeclaration, Identifier, IndexedAccessTypeNode, InterfaceDeclaration, IntersectionTypeNode, LiteralTypeNode, MethodDeclaration, MethodSignature, NamedTupleMember, NewExpression, Node, NumericLiteral, ObjectBindingPattern, ObjectLiteralExpression, ParameterDeclaration, ParenthesizedTypeNode, PropertyAccessExpression, PropertyAssignment, PropertyDeclaration, PropertySignature, QualifiedName, RestTypeNode, SetAccessorDeclaration, SyntaxKind as SK, SourceFile, StringLiteral, SyntaxList, TrueLiteral, TupleTypeNode, TypeAliasDeclaration, TypeLiteralNode, TypeOperatorTypeNode, TypeParameterDeclaration, TypePredicateNode, TypeReferenceNode, UnionTypeNode, VariableDeclaration, VariableStatement } from "ts-morph";
 import { SyntaxKindValidatorMap } from "./SyntaxKindDelegator.types";
 import { Nodely } from "./types";
-export interface SyntaxKindTypeMap<T=never> {
+export interface SyntaxKindTypeMap {
 	[SK.SourceFile]: SourceFile
 	[SK.SyntaxList]: SyntaxList
 	[SK.TypeAliasDeclaration]: TypeAliasDeclaration,

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -2,7 +2,6 @@ import { Node } from "ts-morph";
 import { getDocPath, getFullName, getName } from "./node-tools";
 import { Nodely } from "./types";
 import { getSignature } from "./node-signature";
-import { blue, red } from "console-log-colors";
 
 /*
 Decorators are just a mechanism to color code different parts of the syntax. 

--- a/src/node-signature-map.ts
+++ b/src/node-signature-map.ts
@@ -1,0 +1,51 @@
+import { $kind, $literal, $type } from "./decorators";
+import { sig } from "./node-signature";
+import { getName } from "./node-tools";
+import { arrayLiteral, classDeclaration, enummember, fnSignature, fromName, fromType, fromTypeNode, getAccessor, getOperator, identifier, interfaceDeclaration, intersectionType, literal, literalType, namedTupleMember, newExpression, objLiteral, parameter, propertyAccessExpression, propertyDecSig, typeAliasDeclaration, typeParameter, typeReference, unionType, variableDeclaration } from "./signitors";
+import { combineSyntax } from "./SyntaxKindDelegator";
+import SK, { SKindMap } from "./SyntaxKindDelegator.types";
+import { escape } from "./utils";
+
+export const nodeSignatureMap: SKindMap<string> = {
+	[SK.ArrayType]: node=>sig(node.getElementTypeNode())+'[]',
+	[SK.ParenthesizedType]: node=>`(${fromTypeNode(node)})`,
+	[SK.Constructor]: node=>`${$type("new")} (${node.getParameters().map(p=>sig(p)).join(', ')})=>${$type(getName(node.getParent()))}`,
+	[SK.SetAccessor]: node=> node.getParameters().map(p=>sig(p)).join(', '),
+	[SK.ConditionalType]: node => `${sig(node.getCheckType())} extends ${sig(node.getExtendsType())} ? ${sig(node.getTrueType())}<br/>: ${sig(node.getFalseType())}`,
+	[SK.ExpressionWithTypeArguments]: node => `${sig(node.getExpression())}${node.getTypeArguments().map(a=>sig(a)).join(', ').wrap('<','>')}`,
+	[SK.RestType]: node => `...${fromTypeNode(node)}`,
+	[SK.QualifiedName]: node => `${sig(node.getLeft())}.${sig(node.getRight())}`,
+	[SK.TypePredicate]: node => `${sig(node.getParameterNameNode())} ${node.hasAssertsModifier() ? sig(node.getAssertsModifier()):'is'} ${sig(node.getTypeNode())}`,
+	[SK.TypeOperator]: node => `${$kind(getOperator(node))} ${fromTypeNode(node)}`,
+	[SK.BinaryExpression]: node => `${sig(node.getLeft())} ${sig(node.getOperatorToken())} ${sig(node.getRight())}`,
+	[SK.CallExpression]: node => fromType(node.getReturnType()),
+	[SK.IndexedAccessType]: node => `${sig(node.getObjectTypeNode())}[${node.getIndexTypeNode()}]`,
+	...combineSyntax([SK.FunctionDeclaration,SK.FunctionExpression,SK.MethodDeclaration,SK.FunctionType,SK.MethodSignature,SK.ArrowFunction], fnSignature),
+	...combineSyntax([SK.PropertySignature, SK.PropertyDeclaration, SK.PropertyAssignment], propertyDecSig),
+	...combineSyntax([SK.BindingElement], fromTypeNode),
+	...combineSyntax([SK.ArrayLiteralExpression, SK.TupleType, SK.ArrayBindingPattern], arrayLiteral),
+	...combineSyntax([SK.ObjectLiteralExpression, SK.ObjectBindingPattern, SK.TypeLiteral], objLiteral),
+	...combineSyntax([SK.AsteriskAsteriskEqualsToken, SK.AsteriskAsteriskToken, SK.AsteriskEqualsToken, SK.AsteriskToken, SK.PlusToken, SK.PlusPlusToken, SK.PlusEqualsToken, SK.MinusToken, SK.MinusEqualsToken, SK.MinusEqualsToken, SK.SlashToken, SK.SlashEqualsToken, SK.LessThanToken, SK.LessThanEqualsToken, SK.GreaterThanEqualsToken], node=>escape(node.getText())),
+	...combineSyntax([SK.StringLiteral, SK.NumericLiteral, SK.BigIntLiteral, SK.TrueKeyword, SK.FalseKeyword], literal),
+	[SK.TypeAliasDeclaration]: typeAliasDeclaration,
+	[SK.TypeReference]: typeReference,
+	[SK.TypeParameter]: typeParameter,
+	[SK.NamedTupleMember]: namedTupleMember,
+	[SK.PropertyAccessExpression]: propertyAccessExpression,
+	[SK.UnionType]: unionType,
+	[SK.IntersectionType]: intersectionType,
+	[SK.LiteralType]: literalType,
+	[SK.Identifier]: identifier,
+	[SK.Parameter]: parameter,
+	[SK.ClassDeclaration]: classDeclaration,
+	[SK.ClassExpression]: classDeclaration,
+	[SK.InterfaceDeclaration]: interfaceDeclaration,
+	[SK.GetAccessor]: getAccessor,
+	[SK.VariableDeclaration]: variableDeclaration,
+	[SK.NewExpression]: newExpression,
+	[SK.ObjectKeyword]: ()=>'&lcub;&rcub;',
+	[SK.StringLiteral]: node => $literal(escape(node.getText())),
+	[SK.NumericLiteral]: node => $literal(node.getText()),
+	[SK.EnumDeclaration]: fromName,
+	[SK.EnumMember]: enummember
+}

--- a/src/node-signature.ts
+++ b/src/node-signature.ts
@@ -1,193 +1,11 @@
-import { getDocPath, getFullName, getName, getTypeNode, isPrimitive } from "./node-tools";
-import { ArrowFunction, FunctionDeclaration, FunctionExpression, FunctionTypeNode, MethodDeclaration, MethodSignature, Node, PropertyDeclaration, PropertySignature, ReturnTypedNode, Symbol, Type, TypeFormatFlags, TypeOperatorTypeNode } from "ts-morph";
+import { getFullName, isPrimitive } from "./node-tools";
 import { bySyntax } from "./SyntaxKindDelegator";
-import SK, { SKindMap } from "./SyntaxKindDelegator.types";
-import { $href, $kd, $kind, $link, $literal, $name, $type } from "./decorators";
-import { blue, cyan, gray, green, redBright, yellow, yellowBright } from "console-log-colors";
+import SK from "./SyntaxKindDelegator.types";
+import { $type } from "./decorators";
+import { gray, yellow } from "console-log-colors";
 import { Nodely } from "./types";
 import TS from "./TS";
-import { typelit } from "./constants";
-import { escape } from "./utils";
-
-/**
- * With typenodes not alway being provided this method acts as a point where I can change the logic if getting a typenode fails.
- * @param node 
- * @returns 
- */
-const fromTypeNode = (node: Node): string => {
-	const tn = getTypeNode(node);
-	return tn ? sig(tn)
-	: getSignatureFromType(node) ?? ''
-}
-
-const fromReturn = (node: ReturnTypedNode) => {
-	
-	const tn = node.getReturnTypeNode();
-	const s =  tn ? sig(tn)
-	: fromType(node.getReturnType())
-	return s;
-}
-
-const objLiteral = () => $literal(typelit);
-
-const genTypes = (nodes: Node[], pre: string ='<', post: string = '>') => nodes.map(sig).join(', ').wrap(pre, post);
-
-const isAsync = (node: Node) => {
-	if(!('isAsync' in node) || typeof node.isAsync !== 'function') return false;
-	return node.isAsync();
-}
-const isGenerator = (node: Node) => !('isGenerator' in node) || typeof node.isGenerator !== 'function' ? false:node.isGenerator();
-	
-/**
- * These two declaration types share a common signature. no point in repeating myself. 
- * @param node 
- * @returns 
- */
-const propertyDecSig = (node: PropertyDeclaration | PropertySignature) => `${node.getModifiers().join(', ').wrap('', ' ')}${sig(node.getNameNode())}${node.hasQuestionToken() ? '?':''}: ${fromTypeNode(node)}`;
-
-const fnSignature = (node: FunctionDeclaration | FunctionExpression | MethodDeclaration | FunctionTypeNode | MethodSignature | ArrowFunction) => `${isAsync(node) ? 'async ':''}${isGenerator(node) ? '*':''}${genTypes(node.getTypeParameters())}${getName(node)}(${genTypes(node.getParameters(), '', '')}) =&gt; ${fromReturn(node) || $literal('void')}`;
-
-
-const typingMap: SKindMap<string> = {
-	//functional declarations
-	[SK.FunctionDeclaration]: fnSignature,
-	[SK.FunctionExpression]: fnSignature,
-	[SK.MethodDeclaration]: fnSignature,
-	[SK.FunctionType]: fnSignature,
-	[SK.MethodSignature]: fnSignature,
-	[SK.ArrowFunction]: fnSignature,
-	[SK.PropertySignature]: propertyDecSig,
-	[SK.PropertyDeclaration]: propertyDecSig,
-	[SK.PropertyAssignment]: node => `${sig(node.getNameNode())}${node.hasQuestionToken() ? '?':''}: ${fromTypeNode(node)}`,
-	[SK.NamedTupleMember]: node=>`${node.getDotDotDotToken() ? '...':''}${sig(node.getNameNode())}${node.hasQuestionToken() ? '?':''}: ${fromTypeNode(node)}`,
-	[SK.BindingElement]: fromTypeNode,
-	[SK.PropertyAccessExpression]: node => `${sig(node.getNameNode())}`,
-	[SK.UnionType]: node=>node.getTypeNodes().map(sig).join(' | '),
-	[SK.LiteralType]: node=>$literal(node.getText()),
-	[SK.IntersectionType]: node=>node.getTypeNodes().map(sig).join(' & '),
-	[SK.ArrayType]: node=>`${sig(node.getElementTypeNode())}[]`,
-	[SK.ArrayLiteralExpression]: node=>`[${node.getElements().map(sig)}]`,
-	[SK.TupleType]: node=> genTypes(node.getElements(), '[',']'),
-	[SK.ParenthesizedType]: node=>`(${fromTypeNode(node)})`,
-	[SK.Constructor]: node=>`${$type("new")} (${node.getParameters().map(p=>sig(p)).join(', ')})=>${$type(getName(node.getParent()))}`,
-	[SK.SetAccessor]: node=> node.getParameters().map(p=>sig(p)).join(', '),
-	[SK.ConditionalType]: node => `${sig(node.getCheckType())} extends ${sig(node.getExtendsType())} ? ${sig(node.getTrueType())}<br/>: ${sig(node.getFalseType())}`,
-	[SK.ExpressionWithTypeArguments]: node => `${sig(node.getExpression())}${node.getTypeArguments().map(a=>sig(a)).join(', ').wrap('<','>')}`,
-	[SK.RestType]: node => `...${fromTypeNode(node)}`,
-	[SK.ArrayBindingPattern]: node => genTypes(node.getElements(), '[',']'),
-	[SK.QualifiedName]: node => `${sig(node.getLeft())}.${sig(node.getRight())}`,
-	[SK.TypePredicate]: node => `${sig(node.getParameterNameNode())} ${node.hasAssertsModifier() ? sig(node.getAssertsModifier()):'is'} ${sig(node.getTypeNode())}`,
-	[SK.TypeOperator]: node => `${$kind(getOperator(node))} ${fromTypeNode(node)}`,
-	[SK.BinaryExpression]: node => `${sig(node.getLeft())} ${sig(node.getOperatorToken())} ${sig(node.getRight())}`,
-	[SK.CallExpression]: node => fromType(node.getReturnType()),
-	[SK.IndexedAccessType]: node => `${sig(node.getObjectTypeNode())}[${node.getIndexTypeNode()}]`,
-
-	//object literat expressions or declarations or types
-	[SK.ObjectLiteralExpression]: objLiteral,
-	[SK.ObjectBindingPattern]: objLiteral,
-	[SK.TypeLiteral]: objLiteral,
-	
-	//tokens
-	[SK.AsteriskToken]: () => '*',
-	[SK.AsteriskAsteriskToken]: ()=>'**',
-	[SK.AsteriskEqualsToken]: ()=> '*=',
-	[SK.AsteriskAsteriskEqualsToken]: ()=>'**=',
-	[SK.PlusToken]: ()=> '+',
-	[SK.PlusPlusToken]: ()=>'++',
-	[SK.PlusEqualsToken]: ()=>'+=',
-	[SK.MinusToken]: ()=>'-',
-	[SK.MinusMinusToken]: ()=>'--',
-	[SK.MinusEqualsToken]: ()=>'-=',
-	[SK.SlashToken]: ()=>'/',
-	[SK.SlashEqualsToken]: ()=>'/=',
-	[SK.LessThanToken]: ()=>'&lt;',
-	[SK.LessThanEqualsToken]: ()=>'&lt;=',
-	[SK.GreaterThanToken]: ()=>'&gt;',
-	[SK.GreaterThanEqualsToken]: ()=>'&gt;=',
-	[SK.TypeAliasDeclaration]: (node)=>{
-		return `${node.getName()}${genTypes(node.getTypeParameters())}: ${fromTypeNode(node)}`;
-	},
-	[SK.TypeReference]: node=>{ 
-		const typeName = node.getTypeName();
-		const args = node.getTypeArguments();
-		//corner cases
-		if(typeName.getText() === "Array"){
-			return sig(args[0])+"[]";
-		}
-		return sig(typeName) + args.map(sig).join(', ').wrap('<', '>')
-	},
-	[SK.Identifier]: node=>{
-		const def = node.getDefinitionNodes()[0]; //I guess its possible to have multiple definitions but I havent thought of a use case where I would have reference to all definitions in one location (extensions would have a link back to immediate source automatically)
-		if(!def) return $type(node.getText()); //no link
-		const href = getDocPath(def)
-		if(!href) return $type(node.getText()); //link outside scope
-		return $href(node.getText(), href);
-	},
-	[SK.TypeParameter]: node => {
-		const extension = node.getConstraint()
-		const modifiers = node.getModifiers()
-		return `${modifiers.map(sig).join(' ')}${modifiers.length ? ' ':''}${$name(node.getName())}${(extension ? ' extends ' + sig(extension):'')}`;
-	},
-	[SK.Parameter]: node=>{
-		const typeNode = fromTypeNode(node);
-		const initializer = sig(node.getInitializer());
-		return `${$name((node.isRestParameter() ? '...':'')+sig(node.getNameNode()))}: ${typeNode}${initializer ? ' = '+initializer:''}`;
-	},
-	[SK.ClassDeclaration]: node=>{
-		const extensions = sig(node.getExtends());
-		const implementions = node.getImplements().map(i=>sig(i)).join(', ');
-		return `${getName(node)} ${extensions ? ' extends '+ extensions:''}${implementions ? ' implements ' + implementions:''}`
-	},
-	[SK.ClassExpression]: node=>{
-		const extensions = node.getExtends();
-		const implementations = node.getImplements();
-		return `${$kd`class`} ${extensions ? (' extends ' + sig(extensions)):''}${implementations.map(n=>` implements ${sig(n)}`)}${typelit}`;
-	},
-	[SK.InterfaceDeclaration]: node=>{
-		const extensions = node.getExtends();
-		return `${sig(node.getNameNode())}${extensions.map(node => ` extends ${sig(node)}`).join(' ')}`;
-	},
-	[SK.GetAccessor]: node=> `${node.getModifiers().map(m=>m.getText()).filter(n=>!!n.trim()).join(' ').wrap('', ' ')}${sig(node.getNameNode())}: ${fromReturn(node)}`,
-	[SK.VariableDeclaration]: node => `${getName(node)}: ${fromTypeNode(node)}`,
-	[SK.NewExpression]: node => `${sig(node.getExpression())}${genTypes(node.getTypeArguments())}`,
-	[SK.ObjectKeyword]: () => `&lcub;&rcub;`,
-	[SK.StringLiteral]: node => $literal(escape(node.getText())),
-	[SK.NumericLiteral]: node=> $literal(node.getText()),
-	[SK.BigIntLiteral]: node=>$literal(node.getText()),
-	[SK.TrueKeyword]: node=>$literal(node.getText()),
-	[SK.FalseKeyword]: node=>$literal(node.getText()),
-	[SK.EnumDeclaration]: node=>`${sig(node.getNameNode())}`,
-	[SK.EnumMember]: node=>{
-		const initializer = node.getInitializer();
-		return `${getName(node)}${initializer ? ': '+sig(initializer):''}`;
-	}
-}
-
-/**
- * Converts modifier tokens to plain text
- * @todo style this maybe.
- * @param node 
- * @returns 
- */
-export const getModifiers = (node: Node) => {
-	if(!Node.isModifierable(node)) return [];
-	return node.getModifiers().map(m=>m.getText()).join(' ')+' ';
-}
-
-/**
- * Returns the appropriate operator based on syntax kind. 
- * 
- * could probably just use getText. 
- * @param node 
- * @returns 
- */
-const getOperator = (node: TypeOperatorTypeNode) =>{
-	switch(node.getOperator()){
-		case SK.ReadonlyKeyword: return 'readonly';
-		case SK.KeyOfKeyword: return 'keyof';
-		case SK.UniqueKeyword: return 'unique';
-	}
-}
+import { nodeSignatureMap } from "./node-signature-map";
 
 /**
  * A list of types to be ignored... perhaps I should build this into bySyntax
@@ -197,120 +15,24 @@ const Ignores = new Set([
 ]);
 
 /**
- * A default action 
- * @param n 
- * @returns 
- */
-const defSig = (n: Nodely)=>{
-	if(!n || Ignores.has(n.getKind())) return '';
-	if(isPrimitive(n)) return $type(n.getText());
-
-	TS.err("Signature Missing type", yellow(n.getKindName()), gray(getFullName(n)), n.getText());
-	return "";
-}
-
-/**
  * Just a convenience method to make the same bySyntax method reusable. 
  * @param node 
  * @returns 
  */
-const sig = (node: Nodely) =>  bySyntax(node, typingMap, defSig);
+export const sig = (node: Nodely) =>  (!!node && !Ignores.has(node.getKind())) ? bySyntax(node, nodeSignatureMap, (n: Nodely)=>{
+	if(!n) return '';
+	if(isPrimitive(n)) return $type(n.getText());
+
+	TS.err("Signature Missing type", yellow(n.getKindName()), gray(getFullName(n)), n.getText());
+	return "";
+}):'';
+
 /**
  * Once a full signature name is resolved the typing of the object will be necessary. This typing however will be different for different declaration type. As such I will be handling these similar to the SyntaxKind... I need a SyntaxKind switching function
+ * @todo this is unecessary these functions arent public. 
  * @param node 
  */
 export const getSignature = (node: Nodely) => {
 	return sig(node);
 }
 
-const isPrimitiveType = (t: Type) => t.isAny() || t.isBigInt() || t.isNever() || t.isNull() || t.isNumber() || t.isString() || t.isBoolean() || t.isUndefined();
-
-const isPrimitiveLiteral = (t: Type) => t.isBigIntLiteral() || t.isNumberLiteral() || t.isStringLiteral() || t.isTemplateLiteral() || t.isBooleanLiteral();
-
-/**
- * A utility method allowing me to add in a method to log information when an area that lacks support is encountered. 
- * @param log 
- * @param retVal 
- * @returns 
- */
-const logRet = <T>(log: ()=>void, retVal: T): T => {
-	log();
-	return retVal;
-}
-
-
-const logTypeInfo = (t: Type) => {
-	const props = [
-		'isAny',
-		'isAnonymous',
-		'isArray',
-		'isBigInt',
-		'isBigIntLiteral',
-		'isClass',
-		'isClassOrInterface',
-		'isEnum',
-		'isEnumLiteral',
-		'isInterface',
-		'isIntersection',
-		'isLiteral',
-		'isNever',
-		'isNull',
-		'isNullable',
-		'isNumber',
-		'isNumberLiteral',
-		'isObject',
-		'isReadonlyArray',
-		'isString',
-		'isStringLiteral',
-		'isTemplateLiteral',
-		'isTuple',
-		'isTypeParameter',
-		'isUndefined',
-		'isUnion',
-		'isUnionOrIntersection',
-		'isUnknown',
-		'isVoid',
-	]
-
-	console.log(t.getText(undefined, TypeFormatFlags.NoTruncation | TypeFormatFlags.UseFullyQualifiedType), cyan(t.getFlags()), blue(t.getObjectFlags()), props.map(n=>{
-		if((t[n as keyof Type] as ()=>boolean)()) return green(n);
-		return ''
-	}).filter(n=>!!n.trim()).join('\n'), t.getBaseTypes(), t.getApparentType().getText(), redBright(t.getConstructSignatures().length), yellowBright(t.getCallSignatures().length));
-}
-/**
- * Diving down to the underlying type provides lower level access to the typing however ts-morph provides a wonderul interface via their Node class. Since it completely crawls the Source File it seems more suitable to get the dclaration that is being referenced 
- * @param t 
- * @returns 
- */
-export const fromType = (t: Type | undefined):string => {
-	if(!t) return '';
-	if(isPrimitiveType(t)) return $type(t.getText());
-	if(isPrimitiveLiteral(t)) return $literal(escape(t.getText()));
-
-	const args = t.getTypeArguments().map(fromType).filter(n=>!!n).join(', ').wrap('<', '>');
-	const symbol = t.getSymbol() ?? t.getAliasSymbol();
-	const [dec] = symbol?.getDeclarations() ?? [];
-	if(dec) {
-		return (Node.isExpression(dec) ? (Node.isNewExpression(dec) ? $kd`new`:'') + $link(dec.getParent()!):$link(dec))+args;
-	}
-	return t.isUnion() ? t.getUnionTypes().map(fromType).join(' | ')
-	: t.isArray() ? fromType(t.getArrayElementType()) + '[]'
-	: t.isIntersection() ? t.getIntersectionTypes().map(fromType).join(' & ')
-	: t.isTuple() ? t.getTupleElements().map(fromType).join(', ').wrap('[',']')
-	: '';
-}
-
-export const fromSymbol = (symbol?: Symbol) => {
-	return '';
-}
-/**
- * Attempts to get a type node from the types declaration.
- * @param node 
- * @returns 
- */
-export const getSignatureFromType = (node: Nodely) => {
-	if(!node) return '';
-	const t = node.getType();
-	const tp = fromType(t)
-	return tp;
-}

--- a/src/node-tools.ts
+++ b/src/node-tools.ts
@@ -63,8 +63,27 @@ export const getSignatureName = (node:Node, delim:string=".") => {
 	const family = getFamilyName(node, delim);
 	return `${[family, getName(node)].filter(a=>a).join(delim)}`;
 }
+export const isKeyword = (node: Nodely) => Node.isAnyKeyword(node) 
+|| Node.isInferKeyword(node)
+|| Node.isNeverKeyword(node)
+|| Node.isNumberKeyword(node)
+|| Node.isObjectKeyword(node) //this should probably be handled differently.
+|| Node.isStringKeyword(node)
+|| Node.isSymbolKeyword(node)
+|| Node.isBooleanKeyword(node)
+|| Node.isUndefinedKeyword(node);
 
-export const getJsDocs = (node: Node) => Node.isJSDocable(node) ? node.getJsDocs():[];
+/**
+ * Get the JSDocs if available. 
+ * to avoid potential duplicate documentation explicit corner cases should be used.
+ * 
+ * - variableDeclarations. (the declarations JSDoc should be derived from the statement)
+ * @param node 
+ * @returns 
+ */
+export const getJsDocs = (node: Nodely): JSDoc[] => (Node.isJSDocable(node) && node.getJsDocs())
+|| (Node.isVariableDeclaration(node) && getJsDocs(node.getVariableStatement()))
+|| [];
 
 /**
  * Instead it seems better to just support JSDoc separately from the built in typing. As I integrate properties into the signature process I can omit them from here.
@@ -122,6 +141,10 @@ const ModMap: SKindMap<Modificator> = {
 	}
 }
 
+export const isAsync = (node: Node) => {
+	if(!('isAsync' in node) || typeof node.isAsync !== 'function') return false;
+	return node.isAsync();
+}
 export const getTypeNode = (node?: Node) => (Node.isTyped(node) && node.getTypeNode())
 	|| (Node.isInitializerExpressionGetable(node) || Node.isInitializerExpressionable(node) ? node.getInitializer()
 	:undefined)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -191,12 +191,12 @@ const RENDER_MAP: SKindMap<string> = {
 	},
 	[SK.ExpressionWithTypeArguments]: node=>build(...node.getTypeArguments()),
 	[SK.GetAccessor]: node=> block(
-		$h(4, node, $kd`${node.isStatic() ? 'static ':''}get`, getName(node), ':', getSignature(node)),
+		$s(4, (node.isStatic() ? 'static ':'')+'get', node),
 		getComments(node),
 		getExample(node)
 	),
 	[SK.SetAccessor]: node=>block(
-		$h(4, node, $kd`${node.isStatic() ? 'static ':''}set`, getName(node), ':', getSignature(node)),
+		$s(4, (node.isStatic() ? 'static ':'')+'set', node),
 		getComments(node),
 		getExample(node)
 	),

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,13 +1,14 @@
-import { ArrowFunction, FunctionDeclaration, FunctionExpression, FunctionTypeNode, MethodDeclaration, MethodSignature, NamedTupleMember, Node, ParameterDeclaration, PropertyDeclaration, PropertySignature, SourceFile, Type, TypeParameterDeclaration } from "ts-morph";
+import { ArrowFunction, FunctionDeclaration, FunctionExpression, FunctionTypeNode, MethodDeclaration, MethodSignature, Node, SourceFile, Type } from "ts-morph";
 import { Nodely } from "./types";
 import TS from "./TS";
 import { bySyntax } from "./SyntaxKindDelegator";
 import SK, { SKindMap } from "./SyntaxKindDelegator.types";
-import { $h, $href, $kd, $kind, $link, $literal, $s, $section, $t, $type } from "./decorators";
+import { $h, $kd, $kind, $literal, $s, $section, $t } from "./decorators";
 import { cyan, red, yellow } from "console-log-colors";
-import { declarationOfType, getComments, getDocPath, getExample, getFullName, getName, getTypeNode, isMethodLike, isPrimitive, isPrivate, isStatic } from "./node-tools";
-import { fromType, getModifiers, getSignature, getSignatureFromType } from "./node-signature";
+import { declarationOfType, getComments, getExample, getFullName, getName, getTypeNode, isPrimitive, isPrivate } from "./node-tools";
+import { getSignature } from "./node-signature";
 import { SEP, STORY_BOOK_BLOCK } from "./constants";
+import { fromType } from "./signitors";
 
 
 /**

--- a/src/signitors.ts
+++ b/src/signitors.ts
@@ -1,0 +1,178 @@
+/*
+I just need to split up the logic into more consumable chunks for myself. 
+
+This file will be responsible for providing resusable methods to parse common declaration types
+*/
+
+import { ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, ClassDeclaration, ClassExpression, EnumMember, FunctionDeclaration, FunctionExpression, FunctionTypeNode, GetAccessorDeclaration, Identifier, InterfaceDeclaration, IntersectionTypeNode, LiteralTypeNode, MethodDeclaration, MethodSignature, NamedNode, NamedTupleMember, NewExpression, Node, ParameterDeclaration, PropertyAccessExpression, PropertyAssignment, PropertyDeclaration, PropertySignature, ReturnTypedNode, TupleTypeNode, Type, TypeAliasDeclaration, TypeOperatorTypeNode, TypeParameter, TypeParameterDeclaration, TypeReferenceNode, UnionTypeNode, VariableDeclaration } from "ts-morph";
+import { typelit } from "./constants";
+import { $href, $kd, $link, $literal, $name, $type } from "./decorators";
+import { sig } from "./node-signature";
+import { getDocPath, getFullName, getTypeNode, isAsync } from "./node-tools";
+import SK from "./SyntaxKindDelegator.types";
+import { Nodely } from "./types";
+import { escape } from "./utils";
+
+type Mod<N extends Node> = (node: N) => string
+const modHandler = <N extends Node>(node: N, ...mods: (Mod<N> | string)[]):string => {
+	return mods.reduce((o,v)=>o+(typeof v === 'string' ? v:v(node)) as string, '') as string;
+}
+
+const isPrimitiveType = (t: Type) => t.isAny() || t.isBigInt() || t.isNever() || t.isNull() || t.isNumber() || t.isString() || t.isBoolean() || t.isUndefined();
+
+const isPrimitiveLiteral = (t: Type) => t.isBigIntLiteral() || t.isNumberLiteral() || t.isStringLiteral() || t.isTemplateLiteral() || t.isBooleanLiteral();
+
+
+/**
+ * Diving down to the underlying type provides lower level access to the typing however ts-morph provides a wonderul interface via their Node class. Since it completely crawls the Source File it seems more suitable to get the dclaration that is being referenced 
+ * @param t 
+ * @returns 
+ */
+export const fromType = (t: Type | undefined):string => {
+	if(!t) return '';
+	if(isPrimitiveType(t)) return $type(t.getText());
+	if(isPrimitiveLiteral(t)) return $literal(escape(t.getText()));
+
+	const args = t.getTypeArguments().map(fromType).filter(n=>!!n).join(', ').wrap('<', '>');
+	const symbol = t.getSymbol() ?? t.getAliasSymbol();
+	const [dec] = symbol?.getDeclarations() ?? [];
+	if(dec) {
+		return (Node.isExpression(dec) ? (Node.isNewExpression(dec) ? $kd`new`:'') + $link(dec.getParent()!):$link(dec))+args;
+	}
+	return t.isUnion() ? t.getUnionTypes().map(fromType).join(' | ')
+	: t.isArray() ? fromType(t.getArrayElementType()) + '[]'
+	: t.isIntersection() ? t.getIntersectionTypes().map(fromType).join(' & ')
+	: t.isTuple() ? t.getTupleElements().map(fromType).join(', ').wrap('[',']')
+	: '';
+}
+
+/**
+ * Attempts to get a type node from the types declaration.
+ * @param node 
+ * @returns 
+ */
+export const getSignatureFromType = (node: Nodely) => {
+	if(!node) return '';
+	const t = node.getType();
+	const tp = fromType(t)
+	return tp;
+}
+
+export const fromName = (node: Node) => Node.hasName(node) ? sig(node.getNameNode()):'';
+/**
+ * With typenodes not alway being provided this method acts as a point where I can change the logic if getting a typenode fails.
+ * @param node 
+ * @returns 
+ */
+export const fromTypeNode = (node: Node): string => {
+	const tn = getTypeNode(node);
+	return tn ? sig(tn)
+	: getSignatureFromType(node) ?? ''
+}
+
+export const fromReturn = (node: ReturnTypedNode) => {
+	
+	const tn = node.getReturnTypeNode();
+	const s =  tn ? sig(tn)
+	: fromType(node.getReturnType())
+	return s || $literal('void');
+}
+
+export const genTypes = (nodes: Node[], pre: string ='<', post: string = '>') => nodes.map(sig).join(', ').wrap(pre, post);
+
+export const isGenerator = (node: Node) => !('isGenerator' in node) || typeof node.isGenerator !== 'function' ? false:node.isGenerator();
+
+/**
+ * Returns a literal representation of {...}
+ * @returns 
+ */
+export const objLiteral = () => $literal(typelit);
+
+/**
+ * Converts modifier tokens to plain text
+ * @todo style this maybe.
+ * @param node 
+ * @returns 
+ */
+export const getModifiers = (node: Node) => {
+	if(!Node.isModifierable(node)) return '';
+	return node.getModifiers().map(m=>m.getText()).join(' ').wrap('', ' ');
+}
+
+/**
+ * Returns the appropriate operator based on syntax kind. 
+ * 
+ * could probably just use getText. 
+ * @param node 
+ * @returns 
+ */
+export const getOperator = (node: TypeOperatorTypeNode) =>{
+	switch(node.getOperator()){
+		case SK.ReadonlyKeyword: return 'readonly';
+		case SK.KeyOfKeyword: return 'keyof';
+		case SK.UniqueKeyword: return 'unique';
+	}
+}
+
+export const opt = (node: Node) => (Node.isQuestionTokenable(node) && node.hasQuestionToken()) ? '?':'';
+export const spread = (node: Node) => (Node.isDotDotDotTokenable(node) && node.getDotDotDotToken()) ? '...':'';
+export const getAsync = (node: Node) => isAsync(node) ? 'async ':''
+export const getGenerator = (node: Node) => isGenerator(node) ? '*':'';
+export const getTypeParameters = (node: Node) => genTypes(Node.isTypeParametered(node) ? node.getTypeParameters():[])
+export const getArguments = (node: Node) => `(${Node.isParametered(node) ? node.getParameters().map(sig):[]})`;
+/**
+ * These two declaration types share a common signature. no point in repeating myself. 
+ * @param node 
+ * @returns 
+ */
+export const propertyDecSig = (node: PropertyDeclaration | PropertySignature | PropertyAssignment) => modHandler(node, getModifiers, spread, fromName, opt,': ', fromTypeNode);
+export const fnSignature = (node: FunctionDeclaration | FunctionExpression | MethodDeclaration | FunctionTypeNode | MethodSignature | ArrowFunction) => modHandler(node, getAsync, getGenerator, getTypeParameters,fromName(node),getArguments, ' =&gt; ', fromReturn);
+export const namedTupleMember = (node: NamedTupleMember) => modHandler(node, spread, fromName, opt,': ', fromTypeNode);
+export const propertyAccessExpression = (node: PropertyAccessExpression) => modHandler(node, fromName, opt);
+export const unionType = (node: UnionTypeNode) => node.getTypeNodes().map(sig).join(' | ');
+export const intersectionType = (node: IntersectionTypeNode) => node.getTypeNodes().map(sig).join(' & ');
+export const literalType = (node: LiteralTypeNode) => $literal(node.getText());
+export const arrayLiteral = (node: ArrayLiteralExpression | TupleTypeNode | ArrayBindingPattern) => node.getElements().map(sig).join(', ').wrap('[',']');
+export const typeAliasDeclaration = (node: TypeAliasDeclaration) => modHandler(node, fromName, getTypeParameters, ': ', fromTypeNode);
+export const typeReference = (node: TypeReferenceNode) => {
+	const typeName = node.getTypeName();
+	
+	const args = node.getTypeArguments();
+	if(typeName.getText() === "Array") return sig(args[0])+"[]";
+	return sig(typeName) + args.map(sig).join(', ').wrap('<', '>')
+}
+export const identifier = (node: Identifier) => {
+	const def = node.getDefinitionNodes()[0];
+	if(!def || getFullName(def) === getFullName(node)) return $type(node.getText());
+	const href = getDocPath(def);
+	return href ? $href(node.getText(), href):$type(node.getText());
+}
+export const typeParameter = (node: TypeParameterDeclaration) => {
+	const extension = node.getConstraint();
+	const modifiers = node.getModifiers();
+	return `${modifiers.map(sig).join(' ').wrap('', ' ')}${sig(node.getNameNode())}${extension ? ' extends ' + sig(extension):''}`;
+}
+
+/**
+ * A parameter is a little different then a normal expression in typescript with a parameter typing should be expected or default to any and the initializer should not be used when a typeNode is not present. Also the typ should not be used for this same reason.
+ * @param node 
+ */
+export const parameter = (node: ParameterDeclaration) => {
+	const typeNode = sig(node.getTypeNode()) || $type("any");
+	const initializer = sig(node.getInitializer());
+	return `${node.isRestParameter() ? $name('...'):''}${sig(node.getNameNode())}: ${typeNode}${initializer.wrap(' = ', '')}`;
+}
+
+export const classDeclaration = (node: ClassDeclaration | ClassExpression) => `${Node.isClassDeclaration(node) ? fromName(node):''}${node.getTypeParameters().map(sig).join(', ').wrap('<','>')}${sig(node.getExtends()).wrap(' extends ', '')}${node.getImplements().map(sig).join(', ').wrap(' implements ', '')}`;
+
+export const interfaceDeclaration = (node: InterfaceDeclaration) => fromName(node) + node.getTypeParameters().map(sig).join(', ').wrap('<','>') + node.getExtends().map(sig).join(', ').wrap(' extends ', '');
+
+export const getAccessor = (node: GetAccessorDeclaration) => `${getModifiers(node)}${fromName(node)}: ${fromReturn(node)}`;
+
+export const variableDeclaration = (node: VariableDeclaration) => modHandler(node, fromName,': ', fromTypeNode);
+
+export const newExpression = (node: NewExpression) => `${sig(node.getExpression())}${genTypes(node.getTypeArguments())}`;
+
+export const literal = (node: Node) => $literal(escape(node.getText()));
+
+export const enummember = (node: EnumMember) => fromName(node)+sig(node.getInitializer()).wrap(': ', '');

--- a/src/signitors.ts
+++ b/src/signitors.ts
@@ -4,7 +4,7 @@ I just need to split up the logic into more consumable chunks for myself.
 This file will be responsible for providing resusable methods to parse common declaration types
 */
 
-import { ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, ClassDeclaration, ClassExpression, EnumMember, FunctionDeclaration, FunctionExpression, FunctionTypeNode, GetAccessorDeclaration, Identifier, InterfaceDeclaration, IntersectionTypeNode, LiteralTypeNode, MethodDeclaration, MethodSignature, NamedNode, NamedTupleMember, NewExpression, Node, ParameterDeclaration, PropertyAccessExpression, PropertyAssignment, PropertyDeclaration, PropertySignature, ReturnTypedNode, TupleTypeNode, Type, TypeAliasDeclaration, TypeOperatorTypeNode, TypeParameter, TypeParameterDeclaration, TypeReferenceNode, UnionTypeNode, VariableDeclaration } from "ts-morph";
+import { ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, ClassDeclaration, ClassExpression, EnumMember, Expression, ExpressionableNode, ExtendsClauseableNode, FunctionDeclaration, FunctionExpression, FunctionTypeNode, GetAccessorDeclaration, Identifier, InterfaceDeclaration, IntersectionTypeNode, LiteralTypeNode, MethodDeclaration, MethodSignature, NamedNode, NamedTupleMember, NewExpression, Node, ParameterDeclaration, PropertyAccessExpression, PropertyAssignment, PropertyDeclaration, PropertySignature, ReturnTypedNode, TupleTypeNode, Type, TypeAliasDeclaration, TypeOperatorTypeNode, TypeParameter, TypeParameterDeclaration, TypeReferenceNode, UnionTypeNode, VariableDeclaration } from "ts-morph";
 import { typelit } from "./constants";
 import { $href, $kd, $link, $literal, $name, $type } from "./decorators";
 import { sig } from "./node-signature";
@@ -18,8 +18,18 @@ const modHandler = <N extends Node>(node: N, ...mods: (Mod<N> | string)[]):strin
 	return mods.reduce((o,v)=>o+(typeof v === 'string' ? v:v(node)) as string, '') as string;
 }
 
+/**
+ * Primitive types are simply converted to a string
+ * @param t 
+ * @returns 
+ */
 const isPrimitiveType = (t: Type) => t.isAny() || t.isBigInt() || t.isNever() || t.isNull() || t.isNumber() || t.isString() || t.isBoolean() || t.isUndefined();
 
+/**
+ * Primitive literals are also converted to a string but wrapped in a different wrapper and escaped as they may contain illegal jsx characters.
+ * @param t 
+ * @returns 
+ */
 const isPrimitiveLiteral = (t: Type) => t.isBigIntLiteral() || t.isNumberLiteral() || t.isStringLiteral() || t.isTemplateLiteral() || t.isBooleanLiteral();
 
 
@@ -58,7 +68,14 @@ export const getSignatureFromType = (node: Nodely) => {
 	return tp;
 }
 
+/**
+ * This mod handler simply attempts to parse the name node. This should ultimately end with an identifier but also allow for potential destructured objects to be traversed without change of logic.
+ * @param node 
+ * @returns 
+ */
 export const fromName = (node: Node) => Node.hasName(node) ? sig(node.getNameNode()):'';
+
+export const getExpression = (node: ExpressionableNode | NewExpression) => sig(node.getExpression());
 /**
  * With typenodes not alway being provided this method acts as a point where I can change the logic if getting a typenode fails.
  * @param node 
@@ -70,6 +87,15 @@ export const fromTypeNode = (node: Node): string => {
 	: getSignatureFromType(node) ?? ''
 }
 
+/**
+ * Returns can be explicit or inferred.
+ * 
+ * Similar to a typenode on how its handled.
+ * @todo - prior to checking the type check the jsdocs for a returns or return tag
+ * @todo - traverse the body and collect return expressions manually (this is purely to allow differenciation between class instances and class constructors being returned in the expression.)
+ * @param node 
+ * @returns 
+ */
 export const fromReturn = (node: ReturnTypedNode) => {
 	
 	const tn = node.getReturnTypeNode();
@@ -78,8 +104,20 @@ export const fromReturn = (node: ReturnTypedNode) => {
 	return s || $literal('void');
 }
 
+/**
+ * A convenience method to signature and wrap a statement
+ * @param nodes 
+ * @param pre 
+ * @param post 
+ * @returns 
+ */
 export const genTypes = (nodes: Node[], pre: string ='<', post: string = '>') => nodes.map(sig).join(', ').wrap(pre, post);
 
+/**
+ * Checks if a node is a generator. This is made generic as Arrow functions cant be generators but aside from that can do just about anything else a function can so it does not make sense to have two separate signators.
+ * @param node 
+ * @returns 
+ */
 export const isGenerator = (node: Node) => !('isGenerator' in node) || typeof node.isGenerator !== 'function' ? false:node.isGenerator();
 
 /**
@@ -100,6 +138,18 @@ export const getModifiers = (node: Node) => {
 }
 
 /**
+ * document a contraint
+ * @param node 
+ * @returns 
+ */
+export const getConstraint = (node: TypeParameterDeclaration) => sig(node.getConstraint()).wrap( ' extends ', '');
+
+export const getImplements = (node: ClassDeclaration | ClassExpression) => node.getImplements().map(sig).join(', ').wrap(' implements ', '')
+
+export const getExtend = (node:ClassDeclaration | ClassExpression) => sig(node.getExtends()).wrap(' extends ', '');
+
+export const getExtends = (node:ExtendsClauseableNode) => node.getExtends().map(sig).join(', ').wrap(' extends ', '');
+/**
  * Returns the appropriate operator based on syntax kind. 
  * 
  * could probably just use getText. 
@@ -114,26 +164,124 @@ export const getOperator = (node: TypeOperatorTypeNode) =>{
 	}
 }
 
-export const opt = (node: Node) => (Node.isQuestionTokenable(node) && node.hasQuestionToken()) ? '?':'';
-export const spread = (node: Node) => (Node.isDotDotDotTokenable(node) && node.getDotDotDotToken()) ? '...':'';
-export const getAsync = (node: Node) => isAsync(node) ? 'async ':''
-export const getGenerator = (node: Node) => isGenerator(node) ? '*':'';
-export const getTypeParameters = (node: Node) => genTypes(Node.isTypeParametered(node) ? node.getTypeParameters():[])
-export const getArguments = (node: Node) => `(${Node.isParametered(node) ? node.getParameters().map(sig):[]})`;
 /**
- * These two declaration types share a common signature. no point in repeating myself. 
+ * Checks if value has a question token and if so passes it to the signature.
  * @param node 
  * @returns 
  */
-export const propertyDecSig = (node: PropertyDeclaration | PropertySignature | PropertyAssignment) => modHandler(node, getModifiers, spread, fromName, opt,': ', fromTypeNode);
-export const fnSignature = (node: FunctionDeclaration | FunctionExpression | MethodDeclaration | FunctionTypeNode | MethodSignature | ArrowFunction) => modHandler(node, getAsync, getGenerator, getTypeParameters,fromName(node),getArguments, ' =&gt; ', fromReturn);
-export const namedTupleMember = (node: NamedTupleMember) => modHandler(node, spread, fromName, opt,': ', fromTypeNode);
-export const propertyAccessExpression = (node: PropertyAccessExpression) => modHandler(node, fromName, opt);
+export const opt = (node: Node) => (Node.isQuestionTokenable(node) && node.hasQuestionToken()) ? '?':'';
+
+/**
+ * Checks if a spread symbol precedes the node and if so passes it to the signature. 
+ * @param node 
+ * @returns 
+ */
+export const spread = (node: Node) => (Node.isDotDotDotTokenable(node) && node.getDotDotDotToken()) ? '...':'';
+
+/**
+ * documents a potential async modifier
+ * @param node 
+ * @returns 
+ */
+export const getAsync = (node: Node) => isAsync(node) ? 'async ':''
+
+/**
+ * documents a potential generator modifier.
+ * @param node 
+ * @returns 
+ */
+export const getGenerator = (node: Node) => isGenerator(node) ? '*':'';
+
+/**
+ * documents type parameters.
+ * @param node 
+ * @returns 
+ */
+export const getTypeParameters = (node: Node) => genTypes(Node.isTypeParametered(node) ? node.getTypeParameters():[])
+
+export const getTypeArguments = (node: Node) => genTypes(Node.isTypeArgumented(node) ? node.getTypeArguments():[])
+
+/**
+ * Documents a functions arguments (aka: parameters).
+ * @param node 
+ * @returns 
+ */
+export const getArguments = (node: Node) => `(${Node.isParametered(node) ? node.getParameters().map(sig):[]})`;
+
+/**
+ * These two declaration types share a common signature. no point in repeating myself.
+ * Document a proprty type declaration. 
+ * @param node 
+ * @returns 
+ */
+export const propertyDecSig = (node: PropertyDeclaration | PropertySignature | PropertyAssignment) => modHandler(node,
+	getModifiers, spread, fromName, opt,': ', fromTypeNode);
+
+/**
+ * Document a function type declaration. 
+ * @param node 
+ * @returns 
+ */
+export const fnSignature = (node: FunctionDeclaration | FunctionExpression | MethodDeclaration | FunctionTypeNode | MethodSignature | ArrowFunction) => modHandler(node, 
+	getAsync, getGenerator, getTypeParameters,fromName(node),getArguments, ' =&gt; ', fromReturn);
+
+/**
+ * document a named tuple member.
+ * @param node 
+ * @returns 
+ */
+export const namedTupleMember = (node: NamedTupleMember) => modHandler(node, 
+	spread, fromName, opt,': ', fromTypeNode);
+
+/**
+ * document a property access expression.
+ * @param node 
+ * @returns 
+ */
+export const propertyAccessExpression = (node: PropertyAccessExpression) => modHandler(node, 
+	fromName, opt, sig(node.getExpression()));
+
+/**
+ * Get the type alias declaration
+ * @param node 
+ * @returns 
+ */
+export const typeAliasDeclaration = (node: TypeAliasDeclaration) => modHandler(node, 
+	fromName, getTypeParameters, ': ', fromTypeNode);
+
+/**
+ * Document a union type.
+ * @param node 
+ * @returns 
+ */
 export const unionType = (node: UnionTypeNode) => node.getTypeNodes().map(sig).join(' | ');
+
+/**
+ * Document an intersection type.
+ * @param node 
+ * @returns 
+ */
 export const intersectionType = (node: IntersectionTypeNode) => node.getTypeNodes().map(sig).join(' & ');
-export const literalType = (node: LiteralTypeNode) => $literal(node.getText());
+
+/**
+ * document a literal type
+ * @param node 
+ * @returns 
+ */
+export const literalType = (node: LiteralTypeNode) => $literal(escape(node.getText()));
+
+/**
+ * document an array literal
+ * @param node 
+ * @returns 
+ */
 export const arrayLiteral = (node: ArrayLiteralExpression | TupleTypeNode | ArrayBindingPattern) => node.getElements().map(sig).join(', ').wrap('[',']');
-export const typeAliasDeclaration = (node: TypeAliasDeclaration) => modHandler(node, fromName, getTypeParameters, ': ', fromTypeNode);
+
+/**
+ * document a type reference. funny thing the type reference doesnt create a link. 
+ * @param node 
+ * @returns 
+ */
 export const typeReference = (node: TypeReferenceNode) => {
 	const typeName = node.getTypeName();
 	
@@ -141,17 +289,26 @@ export const typeReference = (node: TypeReferenceNode) => {
 	if(typeName.getText() === "Array") return sig(args[0])+"[]";
 	return sig(typeName) + args.map(sig).join(', ').wrap('<', '>')
 }
+
+/**
+ * An identifier is a sort of reference that points to a definition. if theres a definition and the definition doesnt point back to said node then it becomes a link. 
+ * @todo test this with destructured nodes. 
+ * @param node 
+ * @returns 
+ */
 export const identifier = (node: Identifier) => {
 	const def = node.getDefinitionNodes()[0];
 	if(!def || getFullName(def) === getFullName(node)) return $type(node.getText());
 	const href = getDocPath(def);
 	return href ? $href(node.getText(), href):$type(node.getText());
 }
-export const typeParameter = (node: TypeParameterDeclaration) => {
-	const extension = node.getConstraint();
-	const modifiers = node.getModifiers();
-	return `${modifiers.map(sig).join(' ').wrap('', ' ')}${sig(node.getNameNode())}${extension ? ' extends ' + sig(extension):''}`;
-}
+
+/**
+ * A type parameter 
+ * @param node 
+ * @returns 
+ */
+export const typeParameter = (node: TypeParameterDeclaration) => modHandler(node, getModifiers, fromName, getConstraint);
 
 /**
  * A parameter is a little different then a normal expression in typescript with a parameter typing should be expected or default to any and the initializer should not be used when a typeNode is not present. Also the typ should not be used for this same reason.
@@ -163,15 +320,20 @@ export const parameter = (node: ParameterDeclaration) => {
 	return `${node.isRestParameter() ? $name('...'):''}${sig(node.getNameNode())}: ${typeNode}${initializer.wrap(' = ', '')}`;
 }
 
-export const classDeclaration = (node: ClassDeclaration | ClassExpression) => `${Node.isClassDeclaration(node) ? fromName(node):''}${node.getTypeParameters().map(sig).join(', ').wrap('<','>')}${sig(node.getExtends()).wrap(' extends ', '')}${node.getImplements().map(sig).join(', ').wrap(' implements ', '')}`;
+/**
+ * A class declaration and class express differ at one point and thats the name. 
+ * @param node 
+ * @returns 
+ */
+export const classDeclaration = (node: ClassDeclaration | ClassExpression) => modHandler(node, fromName, getTypeParameters, getExtend, getImplements);
 
-export const interfaceDeclaration = (node: InterfaceDeclaration) => fromName(node) + node.getTypeParameters().map(sig).join(', ').wrap('<','>') + node.getExtends().map(sig).join(', ').wrap(' extends ', '');
+export const interfaceDeclaration = (node: InterfaceDeclaration) => modHandler(node, fromName, getTypeParameters, getExtends);
 
-export const getAccessor = (node: GetAccessorDeclaration) => `${getModifiers(node)}${fromName(node)}: ${fromReturn(node)}`;
+export const getAccessor = (node: GetAccessorDeclaration) => modHandler(node, getModifiers, fromName,': ', fromReturn);
 
 export const variableDeclaration = (node: VariableDeclaration) => modHandler(node, fromName,': ', fromTypeNode);
 
-export const newExpression = (node: NewExpression) => `${sig(node.getExpression())}${genTypes(node.getTypeArguments())}`;
+export const newExpression = (node: NewExpression) => modHandler(node, $kd`new `, getExpression, getTypeArguments,);
 
 export const literal = (node: Node) => $literal(escape(node.getText()));
 


### PR DESCRIPTION
Moved naming into the signatures scope. 

Split up the signature process into three files. it should make managing common code easier. 